### PR TITLE
Login bug fixed

### DIFF
--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -1,2 +1,26 @@
 describe('Login Component', () => {
-}) 
+  const selectors = {
+    nameInput: 'input[name="name"]',
+    passwordInput: 'input[name="password"]',
+    submitButton: 'button[type="submit"]',
+    logoutButton: 'button:contains("Logout")',
+  };
+
+  beforeEach(() => {
+    cy.visit('http://localhost:3000');
+  });
+
+  it('should log in and then log out successfully', () => {
+    // Fill out login form
+    cy.get(selectors.nameInput).type('testing-xpx');
+    cy.get(selectors.passwordInput).type('the tester');
+    cy.get(selectors.submitButton).click();
+
+    // Confirm welcome message is visible
+    cy.contains('Welcome, testing-xpx!').should('be.visible');
+
+    // Click logout and confirm returned to login
+    cy.get(selectors.logoutButton).click();
+    cy.contains('Login').should('be.visible');
+  });
+});

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -15,9 +15,14 @@ function LoginForm({ onLogin }) {
     }));
   };
 
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onLogin(formData);
+  }
+
   return (
     <div className="login-form-container">
-      <form className="login-form">
+      <form className="login-form" onSubmit={handleSubmit}>
         <h2>Login</h2>
         <div className="form-group">
           <label htmlFor="name">Name:</label>


### PR DESCRIPTION
🔧 Fix Login Redirect Bug + Add Cypress E2E Test for Login/Logout Flow
✅ What I Did
Fixed the login bug: The form didn’t trigger the login handler because the onSubmit handler was missing on the <form> element. I fixed this by adding onSubmit={handleSubmit} to the form.

Added Cypress test: Wrote a test that checks the login and logout flow using test credentials (testing-xpx / the tester).

🐛 What Was Wrong
The app didn’t reflect the logged-in state after submission because the component wasn’t conditionally rendering content based on login status. I fixed this by ensuring that the login handler correctly updates the state, and the component renders the welcome screen accordingly.

🧪 Test Coverage
Login with test credentials (testing-xpx / the tester)

Verify welcome message is displayed

Verify logout brings the user back to the login screen

🤖 AI Tool Usage
Used ChatGPT to:

Debug the issue around conditional rendering after login

Generate the initial Cypress test structure