### PR TITLE
fix(login): add form submission handler and e2e test with Cypress

### DIFF
--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -1,2 +1,20 @@
+/* global cy */
+
 describe('Login Component', () => {
+  it('logs in and shows welcome message', () => {
+    cy.visit('/');
+
+    cy.get('input[name="name"]').type('UserName');
+    cy.get('input[name="password"]').type('123456');
+    cy.get('form.login-form').submit();
+
+    cy.contains('Welcome, UserName!').should('be.visible');
+    cy.contains('Logout').should('be.visible');
+
+    cy.get('button.logout-button').click();
+
+    cy.get('form.login-form').should('be.visible');
+    cy.get('input[name="name"]').should('be.visible');
+    cy.get('input[name="password"]').should('be.visible');
+  })
 }) 

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -15,9 +15,14 @@ function LoginForm({ onLogin }) {
     }));
   };
 
+  const handleSubmit = (e) => {
+    e.preventDefault(); 
+    onLogin(formData);  
+  };
+
   return (
     <div className="login-form-container">
-      <form className="login-form">
+      <form className="login-form" onSubmit={handleSubmit}>
         <h2>Login</h2>
         <div className="form-group">
           <label htmlFor="name">Name:</label>


### PR DESCRIPTION
The bug was caused by the login form not handling form submission properly - the onLogin function was never called because there was no onSubmit handler on the <form> element. I fixed this by adding a handleSubmit function that calls onLogin(formData) and attaching it to the form’s onSubmit event.

I used ChatGPT, here are my requests: 
" describe('Login Component', () => {
  it('logs in and shows welcome message', () => {
    cy.visit('/');
  })
}) 
how should I write a Cypress test in a React app without routing?"

"Why do I get 'cy is not defined?"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved login form handling for a smoother user experience.
- **Tests**
  - Added an end-to-end test covering the complete login and logout process, ensuring key UI elements appear as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->