### PR TITLE
add cypress test and fix login redirect bug

### DIFF
--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -1,2 +1,71 @@
 describe('Login Component', () => {
-}) 
+    it('assert that the login form is presented', () => {
+        // Visit the login page
+        cy.visit('http://localhost:3000')
+
+        // Assert the login form is present
+        cy.get('form').should('exist')
+        cy.get('input[name="name"]').should('be.visible')
+        cy.get('input[name="password"]').should('be.visible')
+        cy.get('input[name="password"]').should('have.attr', 'type', 'password')
+    })
+
+    it('type into name input box should show its value', () => {
+        // Visit the login page
+        cy.visit('http://localhost:3000')
+
+        // Type in name input box
+        cy.get('input[name="name"]').type('hello')
+
+        // Check that the name input box's value is correct
+        cy.get('input[name="name"]').should('have.value', 'hello')
+
+        // Check that the password input box's value should not change
+        cy.get('input[name="password"]').should('have.value', '')
+    })
+
+    it('type into password input box should show its value', () => {
+        // Visit the login page
+        cy.visit('http://localhost:3000')
+
+        // Type in password input box
+        cy.get('input[name="password"]').type('123')
+
+        // Check that the password input box's value is correct
+        cy.get('input[name="password"]').should('have.value', '123')
+
+        // Check that the name input box's value should not change
+        cy.get('input[name="name"]').should('have.value', '')
+    })
+
+    it('type into both name and password input box should show correct values', () => {
+        // Visit the login page
+        cy.visit('http://localhost:3000')
+
+        // Type in name and password input box
+        cy.get('input[name="name"]').type('alice')
+        cy.get('input[name="password"]').type('pwd')
+
+        // Check that the name input box's value is correct
+        cy.get('input[name="name"]').should('have.value', 'alice')
+
+        // Check that the password input box's value is correct
+        cy.get('input[name="password"]').should('have.value', 'pwd')
+
+    })
+
+    it('should log in successfully with valid credentials', () => {
+        // Visit the login page
+        cy.visit('http://localhost:3000')
+
+        // Fill in the login form
+        cy.get('input[name="name"]').type('alice')
+        cy.get('input[name="password"]').type('pwd')
+
+        // Click the login button
+        cy.get('button[type="submit"]').click()
+
+        // Wait for the greeting or any element change that indicates successful login
+        cy.contains('Welcome, alice', { timeout: 10000 }).should('be.visible')
+    })
+})

--- a/src/components/LoginForm.js
+++ b/src/components/LoginForm.js
@@ -17,7 +17,10 @@ function LoginForm({ onLogin }) {
 
   return (
     <div className="login-form-container">
-      <form className="login-form">
+      <form className="login-form" onSubmit={(e) => {
+        e.preventDefault();
+        onLogin(formData);
+      }}>
         <h2>Login</h2>
         <div className="form-group">
           <label htmlFor="name">Name:</label>


### PR DESCRIPTION
1. Cypress test file included and passing
See my repo: https://github.com/jingjingwangacc/entry-test-zipboard

2. Bug is fixed and app redirects after login
Done.

3. Short explanation of the bug
Bug: in LoginForm.js, the submit button does not call onLogin. 
Fix: I set the form's onSubmit property to call onLogin with formData as parameter, so onLogin(which is handleLogin defined in App.js) can handle the login event and show the correct username on the Welcome page, also use preventDefault to prevent the default behavior of page reloading when clicking the login button.

4. (Optional) Example of AI tool usage
<img width="1023" alt="Screenshot 2025-05-19 at 3 27 09 PM" src="https://github.com/user-attachments/assets/2d49bf57-d2da-43ff-90bb-a54d8020e212" />

5. Code pushed to a forked GitHub repo
Done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved login form behavior to handle submissions and display a welcome message upon successful login.

- **Tests**
	- Added comprehensive end-to-end tests for the login form, covering input interactions and the complete login flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->